### PR TITLE
chore: remove push trigger from auto-merge, todos, and zizmor workflows

### DIFF
--- a/.github/workflows/test-auto-merge-action.yaml
+++ b/.github/workflows/test-auto-merge-action.yaml
@@ -1,7 +1,5 @@
 name: 🧪 auto-merge-action
 on:
-  push:
-    branches: ["main"]
   pull_request:
 
 permissions:

--- a/.github/workflows/test-todos-action.yaml
+++ b/.github/workflows/test-todos-action.yaml
@@ -1,9 +1,6 @@
 name: 🧪 todos-action
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 permissions:

--- a/.github/workflows/test-zizmor-action.yaml
+++ b/.github/workflows/test-zizmor-action.yaml
@@ -1,8 +1,6 @@
 name: 🧪 zizmor-action
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
 
 permissions: {}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to remove the `push` event trigger for the `main` branch, leaving only the `pull_request` event trigger. This change standardizes the workflows and ensures they are only triggered during pull requests.

Workflow changes:

* [`.github/workflows/test-auto-merge-action.yaml`](diffhunk://#diff-128437f106b38084773021c0804b60fb82ff2ae248949d6c03b24d0b32350245L3-L4): Removed the `push` event trigger for the `main` branch.
* [`.github/workflows/test-todos-action.yaml`](diffhunk://#diff-f34103eecc188021bbaa1163035d01e078840176c8242b42c942ac7e937a1d2bL4-L6): Removed the `push` event trigger for the `main` branch.
* [`.github/workflows/test-zizmor-action.yaml`](diffhunk://#diff-ddee154621552957820feda8211d1d1b1aaae3ca58cb896b09569cd15aaa139dL4-L5): Removed the `push` event trigger for the `main` branch.
